### PR TITLE
Fixing javadoc for Java 8

### DIFF
--- a/src/main/java/com/ibm/watson/developer_cloud/concept_expansion/v1/ConceptExpansion.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/concept_expansion/v1/ConceptExpansion.java
@@ -47,7 +47,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/concept-expansion.html">
  *      Concept Expansion</a>
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  * 
  */
 public class ConceptExpansion extends WatsonService {

--- a/src/main/java/com/ibm/watson/developer_cloud/concept_expansion/v1/model/Concept.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/concept_expansion/v1/model/Concept.java
@@ -22,7 +22,7 @@ import com.ibm.watson.developer_cloud.concept_expansion.v1.ConceptExpansion;
 /**
  * This class map a Concept returned by {@link ConceptExpansion}
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class Concept {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/language_identification/v1/LanguageIdentification.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/language_identification/v1/LanguageIdentification.java
@@ -36,7 +36,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/language-identification.html">
  *      Language Identification</a>
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class LanguageIdentification extends WatsonService {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/language_identification/v1/model/IdentifiedLanguage.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/language_identification/v1/model/IdentifiedLanguage.java
@@ -21,7 +21,7 @@ import com.ibm.watson.developer_cloud.language_identification.v1.LanguageIdentif
 /**
  * Language detected by the {@link LanguageIdentification} service
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class IdentifiedLanguage {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/machine_translation/v1/MachineTranslation.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/machine_translation/v1/MachineTranslation.java
@@ -36,7 +36,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/machine-translation.html">
  *      Machine Translation</a>
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class MachineTranslation extends WatsonService {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/machine_translation/v1/model/Language.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/machine_translation/v1/model/Language.java
@@ -21,7 +21,7 @@ import com.ibm.watson.developer_cloud.machine_translation.v1.MachineTranslation;
 /**
  * Language utilized by the {@link MachineTranslation} service
  *
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class Language {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/message_resonance/v1/MessageResonance.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/message_resonance/v1/MessageResonance.java
@@ -39,7 +39,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/message-resonance.html">
  *      Message Resonance</a>
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class MessageResonance extends WatsonService {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifier.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/NaturalLanguageClassifier.java
@@ -46,7 +46,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  * 
  * @see <a href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/nl-classifier.html"> Natural Language Classifier</a>
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class NaturalLanguageClassifier extends WatsonService {
 
@@ -170,7 +170,7 @@ public class NaturalLanguageClassifier extends WatsonService {
 
 	/**
 	 * Deletes a classifier
-	 * 
+	 * @param classifierId the classifier ID 
 	 * @see Classifier
 	 */
 	public void deleteClassifier(String classifierId) {
@@ -185,6 +185,7 @@ public class NaturalLanguageClassifier extends WatsonService {
 	/**
 	 * Retrieves a classifier
 	 * 
+	 * @param classifierId the classifier ID 
 	 * @return the classifier list
 	 * @see Classifier
 	 */

--- a/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/model/Classification.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/model/Classification.java
@@ -24,7 +24,7 @@ import com.ibm.watson.developer_cloud.natural_language_classifier.v1.NaturalLang
 /**
  * Classification class used by the {@link NaturalLanguageClassifier} service
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class Classification {
 
@@ -70,7 +70,7 @@ public class Classification {
 	/**
 	 * Sets the top class.
 	 * 
-	 * @param top class
+	 * @param topClass class
 	 *            the new top class
 	 */
 	public void setTopClass(String topClass) {

--- a/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/model/ClassifiedClass.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/model/ClassifiedClass.java
@@ -22,7 +22,7 @@ import com.ibm.watson.developer_cloud.natural_language_classifier.v1.NaturalLang
 /**
  * Classified class used by the {@link NaturalLanguageClassifier} service
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class ClassifiedClass {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/model/Classifier.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/model/Classifier.java
@@ -22,7 +22,7 @@ import com.ibm.watson.developer_cloud.natural_language_classifier.v1.NaturalLang
 /**
  * Classifier used by the {@link NaturalLanguageClassifier} service
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class Classifier {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/model/TrainingData.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/natural_language_classifier/v1/model/TrainingData.java
@@ -25,7 +25,7 @@ import com.ibm.watson.developer_cloud.natural_language_classifier.v1.NaturalLang
  * adapt a system to a domain (the ground truth)
  * 
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  * @see NaturalLanguageClassifier
  */
 public class TrainingData {

--- a/src/main/java/com/ibm/watson/developer_cloud/package-info.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/package-info.java
@@ -4,7 +4,7 @@
  * @see com.ibm.watson.developer_cloud.service.WatsonService Watson Service
  * @see <a href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud">
  * IBM Watson Developer Cloud</a>
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 package com.ibm.watson.developer_cloud;
 

--- a/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v2/PersonalityInsights.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v2/PersonalityInsights.java
@@ -39,7 +39,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/personality-insights.html">
  *      Personality Insights</a>
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class PersonalityInsights extends WatsonService {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v2/model/Trait.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/personality_insights/v2/model/Trait.java
@@ -50,7 +50,7 @@ public class Trait {
 	 * Sets the sampling error of the percentage based on the
 	 * number of words in the input.
 	 * 
-	 * @param sampling error
+	 * @param samplingError error
 	 *            the new sampling error
 	 */
 	public void setSamplingError(double samplingError) {

--- a/src/main/java/com/ibm/watson/developer_cloud/question_and_answer/v1/QuestionAndAnswer.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/question_and_answer/v1/QuestionAndAnswer.java
@@ -41,7 +41,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/question-answer.html">
  *      Question and Answer</a>
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class QuestionAndAnswer extends WatsonService {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/relationship_extraction/v1/RelationshipExtraction.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/relationship_extraction/v1/RelationshipExtraction.java
@@ -30,7 +30,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  * components (nouns, verbs, subjects, objects, etc.)
  * 
  * @version v1
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  * @see <a
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/relationship-extraction.html">
  *      Relationship Extraction</a>

--- a/src/main/java/com/ibm/watson/developer_cloud/service/Request.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/service/Request.java
@@ -39,14 +39,15 @@ import com.ibm.watson.developer_cloud.util.RequestUtil;
 
 /**
  * Convenience class for constructing HTTP/HTTPS requests. <br>
- * Example: <code><pre>
+ * Example: <pre>
+ * {@code
  *  HttpRequestBase request = Request
  *     .Get("/v1/translate")
  *     .withQuery("from", "en", "to", "es", "text", "Good Morning")
  *     .build();
- * </pre></code>
+ * }</pre>
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class Request {
 
@@ -329,7 +330,7 @@ public class Request {
 	/**
 	 * Adds a JSON content to the request (used with POST/PUT). This will
 	 * encapsulate the json into a
-	 * {@link org.apache.http.entity.StringEntity.StringEntity StringEntity}
+	 * {@link org.apache.http.entity.StringEntity StringEntity}
 	 * encoded with UTF-8 and use "application/json" as Content-Type
 	 * @param json
 	 *            the JsonObject json
@@ -343,7 +344,7 @@ public class Request {
 	/**
 	 * Adds string content to the request (used with POST/PUT). This will
 	 * encapsulate the string into a
-	 * {@link org.apache.http.entity.StringEntity.StringEntity StringEntity}
+	 * {@link org.apache.http.entity.StringEntity StringEntity}
 	 * encoded with UTF-8
 	 * 
 	 * @param content

--- a/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/service/WatsonService.java
@@ -45,7 +45,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  * Watson service abstract common functionality of various Watson Services. It
  * handle authentication and default url
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  * @see <a
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/">
  *      IBM Watson Developer Cloud</a>

--- a/src/main/java/com/ibm/watson/developer_cloud/service/package-info.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/service/package-info.java
@@ -6,7 +6,7 @@
 
  * @see <a href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud">
  * IBM Watson Developer Cloud</a>
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 package com.ibm.watson.developer_cloud.service;
 

--- a/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/speech_to_text/v1/SpeechToText.java
@@ -40,7 +40,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  * as more speech is heard.
  * 
  * @version v1
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  * @see <a
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/speech-to-text.html">
  *      Speech to Text</a>

--- a/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/text_to_speech/v1/TextToSpeech.java
@@ -35,7 +35,7 @@ import com.ibm.watson.developer_cloud.util.ResponseUtil;
  * back to the client with minimal delay.
  * 
  * @version v1
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  * @see <a
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/text-to-speech.html">
  *      Text to Speech</a>

--- a/src/main/java/com/ibm/watson/developer_cloud/util/MediaType.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/MediaType.java
@@ -21,7 +21,7 @@ package com.ibm.watson.developer_cloud.util;
  * @see <a
  *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7">HTTP/1.1
  *      section 3.7</a>
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class MediaType {
 

--- a/src/main/java/com/ibm/watson/developer_cloud/util/RequestUtil.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/RequestUtil.java
@@ -27,7 +27,7 @@ import org.apache.http.protocol.HTTP;
 /**
  * Utility functions to use when creating a {@link com.ibm.watson.developer_cloud.service.Request }
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class RequestUtil {
 	private static final Logger log = Logger.getLogger(RequestUtil.class

--- a/src/main/java/com/ibm/watson/developer_cloud/util/ResponseUtil.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/util/ResponseUtil.java
@@ -34,7 +34,7 @@ import com.google.gson.JsonParser;
 /**
  * Utility class to manage service responses
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  * @see org.apache.http.HttpResponse HttpResponse
  */
 public class ResponseUtil {
@@ -83,6 +83,8 @@ public class ResponseUtil {
 	 * 
 	 * @param response
 	 *            an HTTP response
+	 * @throws IOException  If an input or output 
+	 * 						exception occurred
 	 * @return the content body as JsonArray
 	 */
 	public static JsonArray getJsonArray(HttpResponse response)
@@ -97,6 +99,8 @@ public class ResponseUtil {
 	 * 
 	 * @param response
 	 *            an HTTP response
+	 * @throws IOException  If an input or output 
+	 * 						exception occurred
 	 * @return the content body as JSONArray
 	 */
 	public static JsonObject getJsonObject(HttpResponse response) throws IOException {

--- a/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v1/VisualRecognition.java
+++ b/src/main/java/com/ibm/watson/developer_cloud/visual_recognition/v1/VisualRecognition.java
@@ -43,7 +43,7 @@ import com.ibm.watson.developer_cloud.visual_recognition.v1.model.VisualRecognit
  *      href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/visual-recognition.html">
  *      Visual Recognition</a>
  * 
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public class VisualRecognition extends WatsonService {
 

--- a/src/test/java/com/ibm/watson/developer_cloud/WatsonServiceTest.java
+++ b/src/test/java/com/ibm/watson/developer_cloud/WatsonServiceTest.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 
 /**
  * Utility class to test the Watson Services
- * @author German Attanasio Ruiz <germanatt@us.ibm.com>
+ * @author German Attanasio Ruiz (germanatt@us.ibm.com)
  */
 public abstract class WatsonServiceTest {
 


### PR DESCRIPTION
Java 8 has stricter javadoc checking (it cannot have <pre> nested in <code>, no '<' and '>' characters in javadoc and some stricter checking on @param names)